### PR TITLE
Update bal_auto_light.weapon

### DIFF
--- a/Weapons/bal_auto_light.weapon
+++ b/Weapons/bal_auto_light.weapon
@@ -12,9 +12,8 @@ weapon
 	model3						barrel_s1_gatling.x
 	turretmodel3				turret_s1standard.x
 
-	turretclass					missile
+	turretclass					standard
 	turretsize					small
-//	munitionsize				tiny
 
 	requires					WEP_LtAutCan
 	cost						200
@@ -40,7 +39,7 @@ weapon
 	fc_holdsfire				true
 	secondary_pd 				true		// Take on point defence role when not otherwise busy
 
-	range						800
+	range						500
 	range_planet				1000
 
 	bolt
@@ -48,26 +47,26 @@ weapon
 		beam_origin						-0.5
 		beam_length						1.5
 
-		effect							effects/l_gatling_bullet.effect
-		impact_effect					effects/l_gatling_impact.effect
-		expire_effect					effects/l_gatling_expire.effect
+		effect							effects/gauss_bullet.effect
+		impact_effect					effects/gauss_impact.effect
+		expire_effect					effects/gauss_expire.effect
 
 		impact_sound					sounds/weapons/bal_gauss_pd_impact.wav
 		impact_sound_minrange			100
 
 		rangetable
 		{
-			pb_range		250
-			pb_range_dev	0
-			pb_range_dam	20
+			pb_range		200
+			pb_range_dev	1
+			pb_range_dam	15
 
-			eff_range		500
-			eff_range_dev	1
-			eff_range_dam	20
+			eff_range		350
+			eff_range_dev	1.5
+			eff_range_dam	15
 
-			max_range		800
-			max_range_dev	1
-			max_range_dam	20
+			max_range		500
+			max_range_dev	2
+			max_range_dam	15
 		}
 
 		ricochet_mod					-1.2		// 1.2 light, 1.3 med, 1.4 heavy
@@ -82,7 +81,7 @@ weapon
 		dam_terra						0.00000001
 	}
 
-	dam_est			20	// approx 2x gauss
+	dam_est			15	// approx 1.5x gauss, but better aim
 
 	rating_frate	10
 	rating_dam		2


### PR DESCRIPTION
Fixed turretclass.
-Decreased range according to Weapons.xlsx sheet.
-Increased **_range_dev to be half of gauss.
-Decreased dmg from 20 to 15
-Changed visual effects to small gauss for better readability, as tiny are barely visible even with full zoom-in on a 32' UHD screen.

Overall, balanced the weapon to be less OP in the tier. Putting it on a strafe bridge becomes less useful in 10vs10+ battles because of the amount of micro needed to aim ships all the time with low maneuverability. However, DEs were not tested against CRs.

Need to update Weapons.xlsx sheet with new data.