### PR TITLE
Update bem_huge_6_pulsedgrav.weapon

### DIFF
--- a/Weapons/bem_huge_6_pulsedgrav.weapon
+++ b/Weapons/bem_huge_6_pulsedgrav.weapon
@@ -7,7 +7,7 @@ weapon
 	model1						barrel_l3_heavydriver.x
 	turretmodel1				turret_l1standard.x
 
-	turretclass					projector
+	turretclass					standard
 	turretsize					large
 
 	requires					WEP_DualPulGrvBm


### PR DESCRIPTION
changed turretclass to standard. Don't know if that will solve it.

Original comment in steam:
«Hey, so I've run into a bug, tri beam graviton pulse beams don't work, they don't fire at all from drednoughts (at least hiver ones) works fine with double barrel versions on cruisers and defence platforms.

The weapon will 'discharge' and every now and then the enemy will just have turrets 'pop' off but no graphic all the time and the turret pop only happens some of the time.»


