### PR TITLE
Police ships speed fix

### DIFF
--- a/Species/Hiver/sections/DEPolice.shipsection
+++ b/Species/Hiver/sections/DEPolice.shipsection
@@ -30,7 +30,7 @@ shipsection
 		torque_pitch		4e+8
 		torque_roll			4e+8
 
-		speed				183.2875
+		speed				120
 		rotspeed			45
 	}
 

--- a/Species/Human/sections/DEpolice.shipsection
+++ b/Species/Human/sections/DEpolice.shipsection
@@ -30,7 +30,7 @@ shipsection
 		torque_pitch		4e+8
 		torque_roll			4e+8
 
-		speed				201.7125
+		speed				120
 		rotspeed			35
 	}
 

--- a/Species/Liir/sections/DEPolice.shipsection
+++ b/Species/Liir/sections/DEPolice.shipsection
@@ -28,7 +28,7 @@ shipsection
 		torque_pitch		6e+8
 		torque_roll			6e+8
 
-		speed				119.2125
+		speed				120
 		rotspeed			55
 	}
 

--- a/Species/Morrigi/sections/DEpolice.shipsection
+++ b/Species/Morrigi/sections/DEpolice.shipsection
@@ -29,7 +29,7 @@ shipsection
 		torque_pitch		5e+8
 		torque_roll			5e+8
 
-		speed				201.7125
+		speed				120
 		rotspeed			55
 	}
 

--- a/Species/Tarkas/sections/DEPolice.shipsection
+++ b/Species/Tarkas/sections/DEPolice.shipsection
@@ -29,7 +29,7 @@ shipsection
 		torque_pitch		2e+8
 		torque_roll			2.4e+8
 
-		speed				174.2125
+		speed				120
 		rotspeed			45
 	}
 


### PR DESCRIPTION
Police ships are too fast for the early game. They can even outrun missiles. It can be cheesed as an early ultrafast missile defence. Especially by hivers.
Changed all police ships' speed to 120